### PR TITLE
Improve player control on conveyors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /src/main/java/gigaherz/
 /src/main/java/net/
 **/Thumbs.db
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -39,3 +39,7 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 }
+
+loom {
+	accessWidenerPath = file("src/main/resources/engination.accesswidener")
+}

--- a/src/main/java/com/elytradev/engination/block/ConveyorBlock.java
+++ b/src/main/java/com/elytradev/engination/block/ConveyorBlock.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Material;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.MovementType;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.DirectionProperty;
@@ -19,7 +20,7 @@ import net.minecraft.world.World;
 
 public class ConveyorBlock extends PressureTriggeredBlock {
 	public static DirectionProperty FACING = Properties.HORIZONTAL_FACING;
-	protected double force = 2.0;
+	protected double force;
 	
 	protected ConveyorBlock(double force) {
 		super(Settings.of(Material.METAL, DyeColor.WHITE).strength(1, 15));
@@ -51,22 +52,6 @@ public class ConveyorBlock extends PressureTriggeredBlock {
 		Direction facing = world.getBlockState(pos).get(FACING);
 		Vec3i vec = facing.getVector();
 		Vec3d motion = new Vec3d(vec.getX()*force, vec.getY()*force, vec.getZ()*force);
-		
-		Vec3d oldVelocity = entity.getVelocity();
-		
-		entity.setVelocity(
-				adjustScalar(oldVelocity.x , motion.x),
-				adjustScalar(oldVelocity.y , motion.y),
-				adjustScalar(oldVelocity.z , motion.z));
-	}
-	
-	private double adjustScalar(double in, double floor) {
-		if (floor<0) {
-			return (floor < in) ? floor : in;
-		} else if (floor>0) {
-			return (floor > in) ? floor : in;
-		}
-		
-		return in;
+		entity.move(MovementType.SELF, motion);
 	}
 }

--- a/src/main/java/com/elytradev/engination/block/EnginationBlocks.java
+++ b/src/main/java/com/elytradev/engination/block/EnginationBlocks.java
@@ -168,9 +168,9 @@ public class EnginationBlocks {
 				"large_tile", "tiles", "dots", "grate", "embossed", "brick", "panel", "t"
 				);
 		
-		block("conveyor", "conveyor",                new ConveyorBlock(2.0), Engination.ENGINATION_GADGETS);
-		block("conveyor", "fast_conveyor",           new ConveyorBlock(4.0), Engination.ENGINATION_GADGETS);
-		block("conveyor", "ultra_fast_conveyor",     new ConveyorBlock(8.0), Engination.ENGINATION_GADGETS);
+		block("conveyor", "conveyor",                new ConveyorBlock(0.2), Engination.ENGINATION_GADGETS);
+		block("conveyor", "fast_conveyor",           new ConveyorBlock(0.4), Engination.ENGINATION_GADGETS);
+		block("conveyor", "ultra_fast_conveyor",     new ConveyorBlock(0.8), Engination.ENGINATION_GADGETS);
 		
 		block("launcher", "launcher",                new LauncherBlock(2.0), Engination.ENGINATION_GADGETS);
 		block("launcher", "forceful_launcher",       new LauncherBlock(3.0), Engination.ENGINATION_GADGETS);

--- a/src/main/java/com/elytradev/engination/block/PressureTriggeredBlock.java
+++ b/src/main/java/com/elytradev/engination/block/PressureTriggeredBlock.java
@@ -42,7 +42,7 @@ public abstract class PressureTriggeredBlock extends Block {
 	
 	@Override
 	public void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity) {
-		if (!(entity instanceof LivingEntity)) return;
+		if (!(entity instanceof LivingEntity le) || le.jumping) return;
 		if (entity instanceof PlayerEntity) {
 			if (world.isClient()) trigger(world, pos, (LivingEntity)entity);
 		} else {

--- a/src/main/resources/engination.accesswidener
+++ b/src/main/resources/engination.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1 named
+accessible field net/minecraft/entity/LivingEntity jumping Z

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,5 +34,6 @@
   },
   "mixins": [
     "engination.client.json"
-  ]
+  ],
+  "accessWidener" : "engination.accesswidener"
 }


### PR DESCRIPTION
... In exchange for funky movement velocity

This is a pretty naive approach - It just replaces the setVelocity-with-fixes approach with a `move()` one.

Access widener added to prevent `onStep` from being called when the entity is jumping (check can be moved to conveyor if needed)

The speed of each conveyor appears to be overall reduced (though sprinting in the same direction does make it a bit faster, the lack of hand bobbing makes it hard to tell it's working)

There's probably a more involved best-of-both-worlds solution for this.